### PR TITLE
Add getCampaignInfo endpoint

### DIFF
--- a/server/controllers/campaign.controller.js
+++ b/server/controllers/campaign.controller.js
@@ -1,6 +1,7 @@
 const {
     createCampaign,
-    getHomeCardInfo
+    getHomeCardInfo,
+    getCampaignInfo
 } = require("../models/CampaignClass");
 
 controller = {};
@@ -22,6 +23,16 @@ controller.homeCardGetter = async (req, res) => {
         res.status(404).send(error.message);
     }
 };
+
+controller.campaignInfoGetter = async (req, res) => {
+    try {
+      const response = await getCampaignInfo(req.params.campaignId);
+  
+      res.send(response);
+    } catch (error) {
+      res.status(404).send(error.message);
+    }
+  };
 
 
 module.exports = controller;

--- a/server/models/CampaignClass.js
+++ b/server/models/CampaignClass.js
@@ -1,4 +1,4 @@
-const { where } = require("firebase/firestore");
+const { where, doc, getDoc } = require("firebase/firestore");
 const { Firestore, db } = require("../utils/firebase_config");
 const userClass = require("../models/UserClass");
 
@@ -204,6 +204,18 @@ class CampaignClass {
         return { message: error.code, status: "error" };
       });
       return reFireStore;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+  static async getCampaignInfo(campaignId) {
+    try {
+      const campaignDocumentRef=doc(db, "campaigns", campaignId);
+      const campaignDocument=await getDoc(campaignDocumentRef);
+      const campaignData=campaignDocument.data()
+      const userData=await userClass.userInfoGet(campaignData);
+      campaignData['user']=userData[0];
+      return campaignData;
     } catch (error) {
       throw new Error(error);
     }

--- a/server/routes/campaign.routes.js
+++ b/server/routes/campaign.routes.js
@@ -4,11 +4,13 @@ const router = express.Router();
 // Controller
 const {
     campaignCreation,
-    homeCardGetter
+    homeCardGetter,
+    campaignInfoGetter
 
 } = require("../controllers/campaign.controller");
 
 // Core
 router.post("/create", campaignCreation);
 router.get("/homeCards/:userId", homeCardGetter)
+router.get("/info/:campaignId", campaignInfoGetter)
 module.exports = router;


### PR DESCRIPTION
### What's new
**New endpoint:**
`localhost:3001/campaign/info/:campaignId` _(get)_
This endpoint is called with a given campaignId, and we use it to reference that campaign in firestore. The result of the query is all the relevant info for that campaign (including the information for the user who created it).

Changes in files:
- added campaign/info/:campaignId route in campaign.routes.js
- added campaignInfoGetter method to campaign.controller.js
- added getCampaignInfo method to CampaignClass.js

### How to use the endpoint
We just call it using the campaignId of the campaign we want info from. It's important to note that if the campaign does not have a valid userId (as in some of the test data), there will be no user in the response object.

**Here is what the request would look like using "V9CRVX7NvfFdRbASOoRe" as the campaignId:**
`localhost:3001/campaign/info/V9CRVX7NvfFdRbASOoRe`

**And here is the response:**
```
{
	"fechaExpiracion": {
		"seconds": 1665378000,
		"nanoseconds": 0
	},
	"categoriaRopa": true,
	"donativosTotales": 0,
	"fechaInicio": {
		"seconds": 1665205200,
		"nanoseconds": 0
	},
	"ubicacion": "En mi casa",
	"isActive": false,
	"userId": "JhcZP5uKzORJ3x0aKPvNfXO0Qoi1",
	"categoriaNoPerecederos": false,
	"categoriaEnseres": false,
	"titulo": "El Electrolit de Coco es superior",
	"categoriaFrutasVerduras": false,
	"metaDonativos": 100,
	"accesibilidad": "Publica",
	"descripcion": "AAAAAAAAAAAAAA",
	"user": {
		"email": "examplecris@user.com",
		"nombre": "Usuario de Ejemplo",
		"userId": "JhcZP5uKzORJ3x0aKPvNfXO0Qoi1",
		"telefono": "123456789"
	}
}
```