### PR TITLE
Fix campaignInfo endpoint

### DIFF
--- a/server/models/CampaignClass.js
+++ b/server/models/CampaignClass.js
@@ -198,8 +198,8 @@ class CampaignClass {
     try {
       const campaignDocumentRef=doc(db, "campaigns", campaignId);
       const campaignDocument=await getDoc(campaignDocumentRef);
-      const campaignData=campaignDocument.data()
-      const userData=await userClass.userInfoGet(campaignData);
+      const campaignData=campaignDocument.data();
+      const userData=await userClass.userInfoGet(campaignData.userId);
       campaignData['user']=userData[0];
       return campaignData;
     } catch (error) {


### PR DESCRIPTION
### What's new
Changed line 202 of CampaignClass.js, which was calling the .userInfoGet method with a JSON instead of userId (which happened because of the fix to that endpoint). This PR fixes the issue and campaignInfo works fine now.