### PR TITLE
Added .env configuration to back-end

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "dotenv": "^16.0.3",
         "firebase": "^9.12.0",
         "nodemon": "^2.0.20"
       }
@@ -773,6 +774,14 @@
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/emoji-regex": {
@@ -2117,6 +2126,11 @@
       "requires": {
         "ms": "^2.1.1"
       }
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "dotenv": "^16.0.3",
     "firebase": "^9.12.0",
     "nodemon": "^2.0.20"
   }

--- a/server/utils/firebase_config.js
+++ b/server/utils/firebase_config.js
@@ -2,13 +2,17 @@ const Firebase = require('firebase/app');
 const FirebaseAuth = require('firebase/auth');
 const Firestore = require('firebase/firestore');
 
+require("dotenv").config();
+
+
+console.log(process.env);
 const firebaseConfig = {
-  apiKey: "AIzaSyCsP7P7orJiW2K5-t5PwdJgi0bfNF8ufgQ",
-  authDomain: "foodbank-manager.firebaseapp.com",
-  projectId: "foodbank-manager",
-  storageBucket: "foodbank-manager.appspot.com",
-  messagingSenderId: "59102412508",
-  appId: "1:59102412508:web:0664a5f0a5ffb189387e19"
+  apiKey: process.env.apiKey,
+  authDomain: process.env.authDomain,
+  projectId: process.env.projectId,
+  storageBucket: process.env.storageBucket,
+  messagingSenderId: process.env.messagingSenderId,
+  appId: process.env.appId
 };
 
 const app = Firebase.initializeApp(firebaseConfig);


### PR DESCRIPTION
### What's new
Created the .env file in the server folder to save apiKey and other secret values. Then we added the implementation for this in the firestore_config.js file.

### IMPORTANT
We used the dotenv node package, to install it use "npm install dotenv --save"