### PR TITLE
Fix HomeCards order

### DIFF
--- a/server/models/CampaignClass.js
+++ b/server/models/CampaignClass.js
@@ -153,8 +153,26 @@ class CampaignClass {
       }
 
       const res = [];
+      
       for (const i in formatedInfo) {
-        res.push(formatedInfo[i]);
+        if(formatedInfo[i].status=='Campaña activa'){
+          res.push(formatedInfo[i])
+        }
+      }
+      for (const i in formatedInfo) {
+        if(formatedInfo[i].status=='Donativo pendiente'){
+          res.push(formatedInfo[i])
+        }
+      }
+      for (const i in formatedInfo) {
+        if(formatedInfo[i].status=='Donativo completado'){
+          res.push(formatedInfo[i])
+        }
+      }
+      for (const i in formatedInfo) {
+        if(formatedInfo[i].status==''){
+          res.push(formatedInfo[i])
+        }
       }
 
       return res;


### PR DESCRIPTION
### What's new
Small change to CampaignClass.js. Although we were returning the campaigns with the correct labels, we were not returning them in the proper display order. This PR fixes the issue. We return an array of JSON objects in the following order:
- Active campaign created by the user (status="Campaña Activa")
- Pending donation (the campaign affiliated with the donation) (status="Donativo pendiente")
- Completed donation (the campaign affiliated with the donation) (status="Donativo completado")
- All other active campaigns (status="")